### PR TITLE
管理者登録時にメールアドレスの重複を防ぐ

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -3,6 +3,7 @@ package com.example.controller;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -74,8 +75,14 @@ public class AdministratorController {
 	 * @return ログイン画面へリダイレクト
 	 */
 	@PostMapping("/insert")
-	public String insert(@Validated InsertAdministratorForm form,
+	public String insert(Model model,
+						@Validated InsertAdministratorForm form,
 						BindingResult result) {
+		Administrator sameEmailAdministrator = administratorService.findByMailAddress(form.getMailAddress()).orElse(null);
+		if (sameEmailAdministrator!=null) {
+			model.addAttribute("errorMessageSameEmail", "そのメールアドレスは既に利用されております");
+			return toInsert(form);
+		}
 		if (result.hasErrors()) {
 			return toInsert(form);
 		}

--- a/src/main/java/com/example/service/AdministratorService.java
+++ b/src/main/java/com/example/service/AdministratorService.java
@@ -1,5 +1,6 @@
 package com.example.service;
 
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,5 +40,16 @@ public class AdministratorService {
 	public Administrator login(String mailAddress, String password) {
 		Administrator administrator = administratorRepository.findByMailAddressAndPassward(mailAddress, password);
 		return administrator;
+	}
+
+	/**
+	 * 引数で渡したメールアドレスと一致する管理者情報を取得
+	 * 
+	 * @param mailAddress
+	 * @return 管理者情報 存在しない場合はnullが返ります
+	 */
+	public Optional<Administrator> findByMailAddress(String mailAddress){
+		Administrator administrator = administratorRepository.findByMailAddress(mailAddress);
+		return Optional.ofNullable(administrator);
 	}
 }

--- a/src/main/java/com/example/validator/UniqueEmailValidator.java
+++ b/src/main/java/com/example/validator/UniqueEmailValidator.java
@@ -1,0 +1,9 @@
+package com.example.validator;
+
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Validator;
+
+@Component
+public class UniqueEmailValidator {
+    
+}

--- a/src/main/resources/templates/administrator/insert.html
+++ b/src/main/resources/templates/administrator/insert.html
@@ -87,6 +87,13 @@
                       >
                         メールアドレスを入力してください
                       </label>
+                      <label
+                        th:if="${errorMessageSameEmail!=null}"
+                        th:text="${errorMessageSameEmail}"
+                        class="error-messages"
+                      >
+                        メールアドレスを入力してください
+                      </label>
                       <input
                         type="text"
                         name="mailAddress"


### PR DESCRIPTION
1.AdministratorServiceにてfindByMailAddresというメールアドレスが一致する管理者を取得するAdministratorRepositoryのメソッドを呼び出す関数を作成した。
2.AdministratorController insert 管理者登録をするメソッドにて、1で作成したサービスクラスのメソッドを呼び出して、
　管理者登録フォームから送られてきたメールアドレスをもつ管理者情報がすでに存在しているなら、エラーメッセージをセットして管理者登録画面へ遷移させる。存在していないなら、通常通り登録メソッドへ進める。