### PR TITLE
管理者新規作成時にパスワードを2回入力させる

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,25 +1,35 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.1.0'
-	id 'io.spring.dependency-management' version '1.1.0'
+	id 'org.springframework.boot' version '3.2.2'
+	id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
+
+java {
+	sourceCompatibility = '21'
+}
+
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+}
 
 repositories {
 	mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'
+	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -78,12 +78,22 @@ public class AdministratorController {
 	public String insert(Model model,
 						@Validated InsertAdministratorForm form,
 						BindingResult result) {
+		//バリデーション以外のエラーがあるかどうか
+		boolean isError = false;
+		//メールアドレスの重複を確認する。
 		Administrator sameEmailAdministrator = administratorService.findByMailAddress(form.getMailAddress()).orElse(null);
 		if (sameEmailAdministrator!=null) {
 			model.addAttribute("errorMessageSameEmail", "そのメールアドレスは既に利用されております");
-			return toInsert(form);
+			isError = true;
 		}
-		if (result.hasErrors()) {
+		//メールアドレスと確認用メールアドレスが一致しているかどうか
+		if (!form.getPassword().equals(form.getConfirmPassword())) {
+			model.addAttribute("errorMessageNotMatchPassword", "パスワードと確認用パスワードが一致しません");
+			isError = true;
+		}
+
+		//バリデーションエラーを確認する。
+		if (result.hasErrors() || isError) {
 			return toInsert(form);
 		}
 		Administrator administrator = new Administrator();

--- a/src/main/java/com/example/form/InsertAdministratorForm.java
+++ b/src/main/java/com/example/form/InsertAdministratorForm.java
@@ -3,6 +3,9 @@ package com.example.form;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * 管理者情報登録時に使用するフォーム.
@@ -10,6 +13,9 @@ import jakarta.validation.constraints.Pattern;
  * @author igamasayuki
  * 
  */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class InsertAdministratorForm {
 	/** 名前 */
 	@NotBlank(message = "名前を入力してください")
@@ -22,35 +28,9 @@ public class InsertAdministratorForm {
 	@NotBlank(message = "パスワードを入力してください")
 	@Pattern(regexp = "^[a-zA-Z0-9.?/-]{8,24}$" ,message = "８文字以上２４文字以内で入力してください。")
 	private String password;
-
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	public String getMailAddress() {
-		return mailAddress;
-	}
-
-	public void setMailAddress(String mailAddress) {
-		this.mailAddress = mailAddress;
-	}
-
-	public String getPassword() {
-		return password;
-	}
-
-	public void setPassword(String password) {
-		this.password = password;
-	}
-
-	@Override
-	public String toString() {
-		return "InsertAdministratorForm [name=" + name + ", mailAddress=" + mailAddress + ", password=" + password
-				+ "]";
-	}
+	/** 確認用パスワード */
+	@NotBlank(message = "パスワードを入力してください")
+	@Pattern(regexp = "^[a-zA-Z0-9.?/-]{8,24}$" ,message = "８文字以上２４文字以内で入力してください。")
+	private String confirmPassword;
 
 }

--- a/src/main/resources/templates/administrator/insert.html
+++ b/src/main/resources/templates/administrator/insert.html
@@ -92,7 +92,7 @@
                         th:text="${errorMessageSameEmail}"
                         class="error-messages"
                       >
-                        メールアドレスを入力してください
+                        メールアドレスがすでに使われております
                       </label>
                       <input
                         type="text"
@@ -126,7 +126,31 @@
                         placeholder="password"
                         th:field="*{password}"
                         th:errorclass="error-input"
-                        value="xxxxxxxx"
+                        value="xxxxxxx"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <!-- 確認用パスワード -->
+                <div class="form-group">
+                  <div class="row">
+                    <div class="col-sm-12">
+                      <label for="confirmPassword"> パスワード(確認用): </label>
+                      <label
+                        th:if="${errorMessageNotMatchPassword!=null}"
+                        th:text="${errorMessageNotMatchPassword}"
+                        class="error-messages"
+                      >
+                        メールアドレスが一致しません。
+                      </label>
+                      <input
+                        type="password"
+                        id="password"
+                        class="form-control"
+                        placeholder="password"
+                        th:field="*{confirmPassword}"
+                        th:errorclass="error-input"
+                        value="xxxxxxx"
                       />
                     </div>
                   </div>


### PR DESCRIPTION
・管理者新規作成時にパスワード（確認用）というフォームを作成した。
・フォームの内容でパスワードとパスワード（確認用）が一致しない場合には、エラーメッセージを出力させ実行をさせない。
・build.gradleの内容を書き換えた。lombokの追加