### PR TITLE
従業員一覧と従業員詳細画面の入社日のフォーマットを変更

### DIFF
--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -132,7 +132,7 @@
                   <tr>
                     <th nowrap>入社日</th>
                     <td>
-                      <span th:utext="${employee.hireDate}">2012/11/29</span>
+                      <span th:utext="${#dates.format(employee.hireDate, 'yyyy年MM月dd日')}">2012/11/29</span>
                     </td>
                   </tr>
                   <tr>

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -107,20 +107,20 @@
               </tr>
             </thead>
             <tbody>
-              <tr th:each="employee : ${employeeList}">
+              <tr th:each="employee : ${employeeList}" th:object="${employee}">
                 <td>
                   <a
                     href="detail.html"
                     th:href="@{'/employee/showDetail?id=' + ${employee.id}}"
                   >
-                    <span th:text="${employee.name}">山田太郎</span>
+                    <span th:text="*{name}">山田太郎</span>
                   </a>
                 </td>
                 <td>
-                  <span th:text="${employee.hireDate}">2016/12/1</span>
+                  <span th:text="*{#dates.format(hireDate, 'yyyy年MM月dd日')}">2016年12月1日</span>
                 </td>
                 <td>
-                  <span th:text="${employee.dependentsCount} + '人'">3人</span>
+                  <span th:text="*{dependentsCount} + '人'">3人</span>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
・employees/list.htmlと/detail.htmlにて入社日を出力する際に、フォーマットを変更してyyyy年MM月dd日を出力するように変更した。