### PR TITLE
従業員詳細画面の給料をカンマ区切りに変更

### DIFF
--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -168,7 +168,7 @@
                   <tr>
                     <th nowrap>給料</th>
                     <td>
-                      <span th:utext="${employee.salary + '円'}">400000円</span>
+                      <span th:text="${T(java.lang.String).format('%,d', employee.salary)+ '円'}">400000円</span>
                     </td>
                   </tr>
                   <tr>


### PR DESCRIPTION
従業員の詳細画面の給料表示のフォーマットを3桁区切りにカンマを入れるように変更した。
・employee/detail　format変更