### PR TITLE
AsministratorRepositoryにてsqlInjection対策をした

### DIFF
--- a/src/main/java/com/example/repository/AdministratorRepository.java
+++ b/src/main/java/com/example/repository/AdministratorRepository.java
@@ -43,8 +43,17 @@ public class AdministratorRepository {
 	 * @return 管理者情報
 	 * @throws org.springframework.dao.DataAccessException 存在しない場合は例外を発生します
 	 */
-	public Administrator load(Integer id) {
-		String sql = "select id,name,mail_address,password from administrators where id=:id";
+	public Administrator findById(Integer id) {
+		String sql = """
+				SELECT
+				  id
+				  ,name
+				  ,mail_address
+				  ,password 
+				FROM
+				 administrators 
+				where id=:id;
+				"""; 
 		SqlParameterSource param = new MapSqlParameterSource().addValue("id", id);
 		Administrator administrator = template.queryForObject(sql, param, ADMINISTRATOR_ROW_MAPPER);
 		return administrator;
@@ -58,9 +67,24 @@ public class AdministratorRepository {
 	 * @return 管理者情報 存在しない場合はnullを返します
 	 */
 	public Administrator findByMailAddressAndPassward(String mailAddress, String password) {
-		String sql = "select id,name,mail_address,password from administrators where mail_address= '" + mailAddress
-				+ "' and password='" + password + "'";
-		SqlParameterSource param = new MapSqlParameterSource();
+		String sql = """
+				SELECT 
+				  id
+				  ,name
+				  ,mail_address
+				  ,password
+				FROM
+				  administrators
+				WHERE
+				  mail_address =:mailAddress
+				AND
+				  password =:password
+				;
+				""";
+		
+		SqlParameterSource param = new MapSqlParameterSource()
+									.addValue("mailAddress", mailAddress)
+									.addValue("password", password);
 		List<Administrator> administratorList = template.query(sql, param, ADMINISTRATOR_ROW_MAPPER);
 		if (administratorList.size() == 0) {
 			return null;

--- a/src/main/java/com/example/repository/EmployeeRepository.java
+++ b/src/main/java/com/example/repository/EmployeeRepository.java
@@ -83,7 +83,7 @@ public class EmployeeRepository {
 	 * @return 検索された従業員情報
 	 * @exception org.springframework.dao.DataAccessException 従業員が存在しない場合は例外を発生します
 	 */
-	public Employee load(Integer id) {
+	public Employee findById(Integer id) {
 		String sql = "SELECT id,name,image,gender,hire_date,mail_address,zip_code,address,telephone,salary,characteristics,dependents_count FROM employees WHERE id=:id";
 
 		SqlParameterSource param = new MapSqlParameterSource().addValue("id", id);

--- a/src/main/java/com/example/service/EmployeeService.java
+++ b/src/main/java/com/example/service/EmployeeService.java
@@ -40,7 +40,7 @@ public class EmployeeService {
 	 * @throws org.springframework.dao.DataAccessException 検索されない場合は例外が発生します
 	 */
 	public Employee showDetail(Integer id) {
-		Employee employee = employeeRepository.load(id);
+		Employee employee = employeeRepository.findById(id);
 		return employee;
 	}
 


### PR DESCRIPTION
管理者情報をメールアドレスとパスワードで絞り込んで取得する際に、入力した値を直接sql文に挿入をしないようにした。
・administartorRepository findByMailAddresAndPassword メソッドで変数をparam.addValue()メソッドでセットすることで、変数をただの文字数として受け取れるようにした。