### PR TITLE
従業員一覧画面に検索欄を追加する

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -138,7 +138,7 @@ public class AdministratorController {
 		}
 		//ログインしているユーザーの情報をsessionに渡す
 		session.setAttribute("administratorName", administrator.getName());
-		return "redirect:/employees/showList";
+		return "redirect:/employees";
 	}
 
 	/////////////////////////////////////////////////////

--- a/src/main/java/com/example/controller/EmployeeController.java
+++ b/src/main/java/com/example/controller/EmployeeController.java
@@ -60,6 +60,11 @@ public class EmployeeController {
 	public String showList(Model model
 							,SearchEmployeeForm form) {
 		List<Employee> employeeList = employeeService.showList(form);
+		if (employeeList.isEmpty()) {
+			form.setName("");
+			employeeList = employeeService.showList(form);
+			model.addAttribute("errorNotEmployee", "１件もありませんでした");
+		}
 		model.addAttribute("employeeList", employeeList);
 		return "employee/list";
 	}
@@ -87,7 +92,6 @@ public class EmployeeController {
         String date = dateFormat.format(employee.getHireDate());
         form.setDependentsCount(employee.getDependentsCount().toString());
         form.setHireDate(date);
-        System.out.println(date);
         return "employee/detail";
     }
 

--- a/src/main/java/com/example/controller/EmployeeController.java
+++ b/src/main/java/com/example/controller/EmployeeController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.example.domain.Employee;
 import com.example.exception.EmployeeNotFoundException;
+import com.example.form.SearchEmployeeForm;
 import com.example.form.UpdateEmployeeForm;
 import com.example.service.EmployeeService;
 
@@ -55,9 +56,10 @@ public class EmployeeController {
 	 * @param model モデル
 	 * @return 従業員一覧画面
 	 */
-	@GetMapping("/showList")
-	public String showList(Model model) {
-		List<Employee> employeeList = employeeService.showList();
+	@GetMapping({"","/"})
+	public String showList(Model model
+							,SearchEmployeeForm form) {
+		List<Employee> employeeList = employeeService.showList(form);
 		model.addAttribute("employeeList", employeeList);
 		return "employee/list";
 	}
@@ -107,6 +109,6 @@ public class EmployeeController {
 		Employee employee = new Employee();
 		employee.setId(Integer.parseInt(id));
 		employeeService.update(employee);
-		return "redirect:/employees/showList";
+		return "redirect:/employees";
 	}
 }

--- a/src/main/java/com/example/form/SearchEmployeeForm.java
+++ b/src/main/java/com/example/form/SearchEmployeeForm.java
@@ -1,0 +1,14 @@
+package com.example.form;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SearchEmployeeForm {
+    
+    /*名前 */
+    private String name;
+}

--- a/src/main/java/com/example/repository/EmployeeRepository.java
+++ b/src/main/java/com/example/repository/EmployeeRepository.java
@@ -51,26 +51,7 @@ public class EmployeeRepository {
 	 * @return 全従業員一覧 従業員が存在しない場合はサイズ0件の従業員一覧を返します
 	 */
 	public List<Employee> findAll(SearchEmployeeForm form) {
-		String sql = """
-					SELECT 
-						id
-						,name
-						,image
-						,gender
-						,hire_date
-						,mail_address
-						,zip_code
-						,address
-						,telephone
-						,salary
-						,characteristics
-						,dependents_count 
-					FROM 
-					  employees
-					ORDER BY 
-					  hire_date desc
-					;
-				""";
+
 		StringBuilder sqlBuilder = new StringBuilder();
 		sqlBuilder.append(" SELECT ");
 		sqlBuilder.append(" e.id ");

--- a/src/main/java/com/example/repository/EmployeeRepository.java
+++ b/src/main/java/com/example/repository/EmployeeRepository.java
@@ -11,6 +11,7 @@ import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
 import com.example.domain.Employee;
+import com.example.form.SearchEmployeeForm;
 
 /**
  * employeesテーブルを操作するリポジトリ.
@@ -49,7 +50,7 @@ public class EmployeeRepository {
 	 * 
 	 * @return 全従業員一覧 従業員が存在しない場合はサイズ0件の従業員一覧を返します
 	 */
-	public List<Employee> findAll() {
+	public List<Employee> findAll(SearchEmployeeForm form) {
 		String sql = """
 					SELECT 
 						id
@@ -70,8 +71,37 @@ public class EmployeeRepository {
 					  hire_date desc
 					;
 				""";
-							
-		List<Employee> developmentList = template.query(sql, EMPLOYEE_ROW_MAPPER);
+		StringBuilder sqlBuilder = new StringBuilder();
+		sqlBuilder.append(" SELECT ");
+		sqlBuilder.append(" e.id ");
+		sqlBuilder.append(" ,e.name ");
+		sqlBuilder.append(" ,e.image ");
+		sqlBuilder.append(" ,e.gender ");
+		sqlBuilder.append(" ,e.hire_date ");
+		sqlBuilder.append(" ,e.mail_address ");
+		sqlBuilder.append(" ,e.zip_code ");
+		sqlBuilder.append(" ,e.address ");
+		sqlBuilder.append(" ,e.telephone ");
+		sqlBuilder.append(" ,e.salary ");
+		sqlBuilder.append(" ,e.characteristics ");
+		sqlBuilder.append(" ,e.dependents_count  ");
+		sqlBuilder.append(" FROM ");
+		sqlBuilder.append(" employees e ");
+		sqlBuilder.append(" WHERE 1 = 1 ");
+
+		String nameKeyWord = form.getName();
+		if (nameKeyWord!=null && !nameKeyWord.equals("")) {
+			sqlBuilder.append(" AND ");
+			sqlBuilder.append(" e.name LIKE '%");
+			sqlBuilder.append(nameKeyWord);
+			sqlBuilder.append("%' ");
+		}
+
+		sqlBuilder.append(" ORDER BY ");
+		sqlBuilder.append(" e.hire_date desc ;");
+		
+		String findAllSql = sqlBuilder.toString();
+		List<Employee> developmentList = template.query(findAllSql, EMPLOYEE_ROW_MAPPER);
 
 		return developmentList;
 	}

--- a/src/main/java/com/example/service/EmployeeService.java
+++ b/src/main/java/com/example/service/EmployeeService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.domain.Employee;
+import com.example.form.SearchEmployeeForm;
 import com.example.repository.EmployeeRepository;
 
 /**
@@ -28,8 +29,8 @@ public class EmployeeService {
 	 * 
 	 * @return 従業員情報一覧
 	 */
-	public List<Employee> showList() {
-		List<Employee> employeeList = employeeRepository.findAll();
+	public List<Employee> showList(SearchEmployeeForm form) {
+		List<Employee> employeeList = employeeRepository.findAll(form);
 		return employeeList;
 	}
 

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -44,7 +44,7 @@
             <a
               class="navbar-brand"
               href="list.html"
-              th:href="@{/employees/showList}"
+              th:href="@{/employees}"
             >
               <!-- 企業ロゴ -->
               <img
@@ -61,7 +61,7 @@
           >
             <ul class="nav navbar-nav">
               <li class="active">
-                <a href="list.html" th:href="@{/employees/showList}"
+                <a href="list.html" th:href="@{/employees}"
                   >従業員管理</a
                 >
               </li>
@@ -84,7 +84,7 @@
 
       <!-- パンくずリスト -->
       <ol class="breadcrumb">
-        <li><a th:href="@{/employees/showList}" th:text="従業員リスト"></a></li>
+        <li><a th:href="@{/employees}" th:text="従業員リスト"></a></li>
         <li class="active">従業員詳細</li>
       </ol>
 

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -44,7 +44,7 @@
             <a
               class="navbar-brand"
               href="list.html"
-              th:href="@{/employees/showList}"
+              th:href="@{/employees}"
             >
               <!-- 企業ロゴ -->
               <img
@@ -61,7 +61,7 @@
           >
             <ul class="nav navbar-nav">
               <li class="active">
-                <a href="list.html" th:href="@{/employees/showList}"
+                <a href="list.html" th:href="@{/employees}"
                   >従業員管理</a
                 >
               </li>
@@ -85,7 +85,7 @@
       <!-- パンくずリスト -->
       <ol class="breadcrumb">
         <li class="active">
-          <a href="list.html" th:href="@{/employees/showList}">従業員リスト</a>
+          <a href="list.html" th:href="@{/employees}">従業員リスト</a>
         </li>
       </ol>
 
@@ -95,7 +95,17 @@
           class="table-responsive col-lg-offset-2 col-lg-8 col-md-offset-2 col-md-8 col-sm-12 col-xs-12"
         >
           <!-- ここから上を編集する必要はありません -->
-
+        <div>
+          <h3>従業員検索</h3>
+          <div>
+            <form th:action="@{/employees}" method="get" th:object="${searchEmployeeForm}">
+              <label for="name">名前:</label>
+              <input type="text" th:field="*{name}">
+              <br>
+              <button>検索する</button>
+            </form>
+          </div>
+        </div>
           <!-- ここにモックのtable要素を貼り付けます -->
 
           <table class="table table-striped">

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -98,6 +98,13 @@
         <div>
           <h3>従業員検索</h3>
           <div>
+            <label
+              th:if="${errorNotEmployee!=null}"
+              th:text="${errorNotEmployee}"
+              class="error-messages"
+            >
+              １件もありませんでした
+            </label>
             <form th:action="@{/employees}" method="get" th:object="${searchEmployeeForm}">
               <label for="name">名前:</label>
               <input type="text" th:field="*{name}">

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -9,6 +9,6 @@
     <h1>404</h1>
     <h3>お探しのページは見つかりません</h3>
     <a th:href="@{/login}" th:text="ログイン画面へ"></a>
-    <a th:href="@{/employees/showList}" th:text="従業員一覧へ"></a>
+    <a th:href="@{/employees}" th:text="従業員一覧へ"></a>
 </body>
 </html>

--- a/src/main/resources/templates/error/500.html
+++ b/src/main/resources/templates/error/500.html
@@ -9,6 +9,6 @@
     <h1>500</h1>
     <h3>メンテナンス中</h3>
     <a th:href="@{/login}" th:text="ログイン画面へ"></a>
-    <a th:href="@{/employees/showList}" th:text="従業員一覧へ"></a>
+    <a th:href="@{/employees}" th:text="従業員一覧へ"></a>
 </body>
 </html>


### PR DESCRIPTION
# 従業員検索追加
- 従業員一覧画面に名前のあいまい検索ができるフォームの追加
- EmployeeRepositoryにてフォームから値を受け取った場合に、sql文を追加して、絞り込みができるようにした
- 検索の結果、１件も見つからない場合は、メッセージとともに全件検索に切り替える。